### PR TITLE
feat: Filtered policy support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,6 +26,7 @@
   },
   "env": {
     "node": true,
-    "jest": true
+    "jest": true,
+    "es6": true
   }
 }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -20,10 +20,6 @@ export interface SequelizeAdapterOptions extends SequelizeOptions {
   tableName?: string;
 }
 
-export type CasbinRuleFilter = Array<string | null | undefined>;
-
-export type CasbinFilter = Record<string, CasbinRuleFilter>;
-
 /**
  * SequelizeAdapter represents the Sequelize adapter for policy storage.
  */

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -34,11 +34,11 @@ export class SequelizeAdapter implements Adapter {
   }
 
   public isFiltered(): boolean {
-      return this.filtered;
+    return this.filtered;
   }
 
   public enabledFiltered(enabled: boolean): void {
-      this.filtered = enabled;
+    this.filtered = enabled;
   }
 
   /**
@@ -240,29 +240,33 @@ export class SequelizeAdapter implements Adapter {
    */
   public async loadFilteredPolicy(
     model: Model,
-    filter: { [key: string]: string[][] },
-  ): Promise<void>  {
-    const whereStatements = Object.keys(filter)
-      .map((ptype) => {
-        const policyPatterns = filter[ptype];
-        return policyPatterns.map((policyPattern) => {
-          return {
-            ptype,
-            ...(policyPattern[0]) && { v0: policyPattern[0] },
-            ...(policyPattern[1]) && { v1: policyPattern[1] },
-            ...(policyPattern[2]) && { v2: policyPattern[2] },
-            ...(policyPattern[3]) && { v3: policyPattern[3] },
-            ...(policyPattern[4]) && { v4: policyPattern[4] },
-            ...(policyPattern[5]) && { v5: policyPattern[5] },
-          };
-        });
+    filter: { [key: string]: string[][] }
+  ): Promise<void> {
+    const whereStatements = Object.keys(filter).map((ptype) => {
+      const policyPatterns = filter[ptype];
+      return policyPatterns.map((policyPattern) => {
+        return {
+          ptype,
+          ...(policyPattern[0] && { v0: policyPattern[0] }),
+          ...(policyPattern[1] && { v1: policyPattern[1] }),
+          ...(policyPattern[2] && { v2: policyPattern[2] }),
+          ...(policyPattern[3] && { v3: policyPattern[3] }),
+          ...(policyPattern[4] && { v4: policyPattern[4] }),
+          ...(policyPattern[5] && { v5: policyPattern[5] }),
+        };
       });
+    });
 
     const where = {
-      [Op.or]: whereStatements.reduce((accumulator, value) => accumulator.concat(value), []),
-    }
+      [Op.or]: whereStatements.reduce(
+        (accumulator, value) => accumulator.concat(value),
+        []
+      ),
+    };
 
-    const lines = await this.sequelize.getRepository(CasbinRule).findAll({ where });
+    const lines = await this.sequelize
+      .getRepository(CasbinRule)
+      .findAll({ where });
 
     lines.forEach((line) => this.loadPolicyLine(line, model));
     this.enabledFiltered(true);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -225,6 +225,55 @@ export class SequelizeAdapter implements Adapter {
   }
 
   /**
+   * loadFilteredPolicy loads policy rules that match the filter from the storage
+   */
+  public async loadFilteredPolicy(
+    model: Model,
+    sec: string,
+    ptype: string,
+    fieldIndex: number,
+    ...fieldValues: string[]
+  ): Promise<void>  {
+    const line = new CasbinRule();
+    line.ptype = ptype;
+
+    const idx = fieldIndex + fieldValues.length;
+    if (fieldIndex <= 0 && 0 < idx) {
+      line.v0 = fieldValues[0 - fieldIndex];
+    }
+    if (fieldIndex <= 1 && 1 < idx) {
+      line.v1 = fieldValues[1 - fieldIndex];
+    }
+    if (fieldIndex <= 2 && 2 < idx) {
+      line.v2 = fieldValues[2 - fieldIndex];
+    }
+    if (fieldIndex <= 3 && 3 < idx) {
+      line.v3 = fieldValues[3 - fieldIndex];
+    }
+    if (fieldIndex <= 4 && 4 < idx) {
+      line.v4 = fieldValues[4 - fieldIndex];
+    }
+    if (fieldIndex <= 5 && 5 < idx) {
+      line.v5 = fieldValues[5 - fieldIndex];
+    }
+
+    const where = {};
+
+    Object.keys(line.get({ plain: true }))
+      .filter((key) => key !== 'id')
+      .forEach((key) => {
+        // @ts-ignore
+        where[key] = line[key];
+      });
+
+    const lines = await this.sequelize.getRepository(CasbinRule).findAll({
+      where,
+    });
+
+    lines.forEach((line) => this.loadPolicyLine(line, model));
+  }
+
+  /**
    * removeFilteredPolicy removes policy rules that match the filter from the storage.
    */
   public async removeFilteredPolicy(

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -250,8 +250,6 @@ export class SequelizeAdapter implements Adapter {
         };
       });
 
-      console.log(JSON.stringify({ whereStatements }, undefined, 2));
-
     await Promise.all(whereStatements.map(((where) => this.sequelize.getRepository(CasbinRule).findAll({
       where,
     }).then((rules) => {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -26,9 +26,18 @@ export interface SequelizeAdapterOptions extends SequelizeOptions {
 export class SequelizeAdapter implements Adapter {
   private readonly option: SequelizeAdapterOptions;
   private sequelize: Sequelize;
+  private filtered = false;
 
   constructor(option: SequelizeAdapterOptions) {
     this.option = option;
+  }
+
+  public isFiltered(): boolean {
+      return this.filtered;
+  }
+
+  public enabledFiltered(enabled: boolean): void {
+      this.filtered = enabled;
   }
 
   /**
@@ -251,6 +260,7 @@ export class SequelizeAdapter implements Adapter {
     }).then((rules) => {
       return rules.forEach(((rule) => this.loadPolicyLine(rule, model)))
     }))));
+    this.enabledFiltered(true);
   }
 
   /**

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -26,7 +26,7 @@ async function testGetGroupingPolicy(
   e: Enforcer,
   res: string[][]
 ): Promise<void> {
-  const myRes = e.getGroupingPolicy();
+  const myRes = await e.getGroupingPolicy();
   console.log('GroupingPolicy: ', myRes);
 
   expect(Util.array2DEquals(res, await myRes)).toBe(true);
@@ -148,6 +148,35 @@ test(
       // Remove groupingPolicy from DB
       await e.deleteUser('alice');
       testGetGroupingPolicy(e, []);
+
+      // Clear the current policy.
+      e.clearPolicy();
+      testGetPolicy(e, []);
+
+      // test load simple filtered policy
+      await a.loadFilteredPolicy(e.getModel(), {
+        p: [['data2_admin']],
+      });
+      testGetPolicy(e, [
+        ['data2_admin', 'data2', 'read'],
+        ['data2_admin', 'data2', 'write'],
+      ]);
+
+      // Clear the current policy.
+      e.clearPolicy();
+      testGetPolicy(e, []);
+      // test load filtered policy
+      await a.loadFilteredPolicy(e.getModel(), {
+        p: [['data2_admin']],
+      });
+      testGetPolicy(e, [
+        ['data2_admin', 'data2', 'read'],
+        ['data2_admin', 'data2', 'write'],
+      ]);
+
+      // Clear the current policy.
+      e.clearPolicy();
+      testGetPolicy(e, []);
     } finally {
       await a.close();
     }

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -181,10 +181,7 @@ test(
 
       // test load filtered policy
       await a.loadFilteredPolicy(e.getModel(), {
-        p: [
-          ['data2_admin'],
-          ['bob'],
-        ],
+        p: [['data2_admin'], ['bob']],
       });
       testGetPolicy(e, [
         ['bob', 'data2', 'write'],

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -16,10 +16,10 @@ import { newEnforcer, Enforcer, Util } from 'casbin';
 import { SequelizeAdapter } from '../src/adapter';
 
 async function testGetPolicy(e: Enforcer, res: string[][]): Promise<void> {
-  const myRes = e.getPolicy();
+  const myRes = await e.getPolicy();
   console.log('Policy: ', myRes);
 
-  expect(Util.array2DEquals(res, await myRes)).toBe(true);
+  expect(Util.array2DEquals(res, myRes)).toBe(true);
 }
 
 async function testGetGroupingPolicy(

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -165,11 +165,29 @@ test(
       // Clear the current policy.
       e.clearPolicy();
       testGetPolicy(e, []);
+
       // test load filtered policy
       await a.loadFilteredPolicy(e.getModel(), {
         p: [['data2_admin']],
       });
       testGetPolicy(e, [
+        ['data2_admin', 'data2', 'read'],
+        ['data2_admin', 'data2', 'write'],
+      ]);
+
+      // Clear the current policy.
+      e.clearPolicy();
+      testGetPolicy(e, []);
+
+      // test load filtered policy
+      await a.loadFilteredPolicy(e.getModel(), {
+        p: [
+          ['data2_admin'],
+          ['bob'],
+        ],
+      });
+      testGetPolicy(e, [
+        ['bob', 'data2', 'write'],
         ['data2_admin', 'data2', 'read'],
         ['data2_admin', 'data2', 'write'],
       ]);

--- a/test/adapter.test.ts
+++ b/test/adapter.test.ts
@@ -29,7 +29,7 @@ async function testGetGroupingPolicy(
   const myRes = await e.getGroupingPolicy();
   console.log('GroupingPolicy: ', myRes);
 
-  expect(Util.array2DEquals(res, await myRes)).toBe(true);
+  expect(Util.array2DEquals(res, myRes)).toBe(true);
 }
 
 test(


### PR DESCRIPTION
## Support for Filtered Policy

### Why?
In certain implementations, the casbin rule data store gets quite large for ABAC in an enterprise solution. I would love to be able to use the sequelize adapter with filtered policies in order to load policies by client domains, for example.

### What this should do
* Added one new method called `loadFilteredPolicy` according to the [casbin adapter documentation](https://casbin.org/docs/en/adapters)
* Added a test for loading a filtered policy
* Added `"es6": true` to the `.eslintrc` to support `await Promise.all()`. Although I'm happy to revise this to use the syntax of choice.
* Moved an `await` statement in `testGetPolicy` so that you can actually read the policy in the logs during testing:
before:
<img width="319" alt="Screen Shot 2022-05-25 at 2 24 09 PM" src="https://user-images.githubusercontent.com/14983357/170338957-b79b6b09-5cd0-42ca-8cac-c21b3a52316b.png">
after:
<img width="425" alt="Screen Shot 2022-05-25 at 2 24 53 PM" src="https://user-images.githubusercontent.com/14983357/170339066-73213c55-3737-42d5-be80-c5dad3bf8782.png">


### How to test
`yarn test`:
<img width="402" alt="Screen Shot 2022-05-25 at 2 19 39 PM" src="https://user-images.githubusercontent.com/14983357/170338131-46276078-8240-4def-95b0-a729eba606af.png">

