### PR TITLE
feat: Optionally set the schema for table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Yarn Install
 yarn add casbin-sequelize-adapter
 ```
 
-## Testing
+## Testing Locally
 
 Start mysql for tests:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,29 @@ You may find other 3rd-party supported DBs in Sequelize website or other places.
 
 ## Installation
 
-    npm install casbin-sequelize-adapter --save
+NPM Install
+
+```bash
+npm install casbin-sequelize-adapter --save
+```
+
+Yarn Install
+
+```bash
+yarn add casbin-sequelize-adapter
+```
+
+## Testing
+
+Start mysql for tests:
+
+```bash
+docker compose up -d
+```
+
+```bash
+yarn test
+```
 
 ## Simple Example
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+  db:
+    image: mysql:latest
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: yes
+    volumes:
+      - ./mysql_init.sql:/docker-entrypoint-initdb.d/mysql_init.sql

--- a/mysql_init.sql
+++ b/mysql_init.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE casbin;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -19,6 +19,7 @@ import { CasbinRule, updateCasbinRule } from './casbinRule';
 
 export interface SequelizeAdapterOptions extends SequelizeOptions {
   tableName?: string;
+  schema?: string;
 }
 
 /**

--- a/src/casbinRule.ts
+++ b/src/casbinRule.ts
@@ -44,7 +44,10 @@ export class CasbinRule extends Model<CasbinRule> {
   public v5: string;
 }
 
-export function updateCasbinRule(tableName = 'casbin_rule', schema?: string): void {
+export function updateCasbinRule(
+  tableName = 'casbin_rule',
+  schema?: string
+): void {
   const options = getOptions(CasbinRule.prototype);
   options!.tableName = tableName;
   options!.schema = schema;

--- a/src/casbinRule.ts
+++ b/src/casbinRule.ts
@@ -44,8 +44,9 @@ export class CasbinRule extends Model<CasbinRule> {
   public v5: string;
 }
 
-export function updateCasbinRule(tableName = 'casbin_rule'): void {
+export function updateCasbinRule(tableName = 'casbin_rule', schema?: string): void {
   const options = getOptions(CasbinRule.prototype);
   options!.tableName = tableName;
+  options!.schema = schema;
   setOptions(CasbinRule.prototype, options!);
 }


### PR DESCRIPTION
### Support to optionally set the schema for table
---
#### Why?

Some RDBMS support the idea of `schema` being a separated namespace under a database, e.g. [Postgres](https://www.postgresql.org/docs/current/ddl-schemas.html). 

#### What was changed?

1. Propagate the `schema` option to the table creation exactly how `tableName` was propagated.
2. Updated README to include instructions on how to test locally