### PR TITLE
fix: Require a frozen lockfile when build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 12
-      - run: yarn
+      - run: yarn install --frozen-lockfile
       - run: mysql --host 127.0.0.1 --port 3306 -uroot -p -e "CREATE DATABASE casbin"
       - run: yarn format:check
       - run: yarn lint
@@ -56,7 +56,7 @@ jobs:
       - name: Run semantic-release
         if: github.repository == 'node-casbin/sequelize-adapter' && github.event_name == 'push'
         run: |
-          yarn install --no-lockfile
+          yarn install --frozen-lockfile
           mysql --host 127.0.0.1 --port 3306 -uroot -p -e "CREATE DATABASE casbin"
           yarn run prepack
           yarn run release


### PR DESCRIPTION
Fix: https://github.com/node-casbin/sequelize-adapter/issues/65

"--frozen-lockfile" will make it so that the yarn build process is reproducible and uses the versions of dependencies defined in the "yarn.lock" file.

From the [yarn docs](https://classic.yarnpkg.com/lang/en/docs/cli/install/):
> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.
> 
> ...
>
> yarn install --frozen-lockfile
>
> Don’t generate a yarn.lock lockfile and fail if an update is needed.
