### PR TITLE
feat: Optionally skip create table with argument to newAdapter

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -49,9 +49,10 @@ export class SequelizeAdapter implements Adapter {
    * @param option sequelize connection option
    */
   public static async newAdapter(
-    option: SequelizeAdapterOptions
+    option: SequelizeAdapterOptions,
+    autoCreate?: boolean
   ): Promise<SequelizeAdapter> {
-    const a = new SequelizeAdapter(option);
+    const a = new SequelizeAdapter(option, autoCreate);
     await a.open();
 
     return a;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -29,9 +29,11 @@ export class SequelizeAdapter implements Adapter {
   private readonly option: SequelizeAdapterOptions;
   private sequelize: Sequelize;
   private filtered = false;
+  private autoCreate = true;
 
-  constructor(option: SequelizeAdapterOptions) {
+  constructor(option: SequelizeAdapterOptions, autoCreate = true) {
     this.option = option;
+    this.autoCreate = autoCreate;
   }
 
   public isFiltered(): boolean {
@@ -60,7 +62,9 @@ export class SequelizeAdapter implements Adapter {
     updateCasbinRule(this.option.tableName);
     await this.sequelize.authenticate();
     this.sequelize.addModels([CasbinRule]);
-    await this.createTable();
+    if (this.autoCreate) {
+      await this.createTable();
+    }
   }
 
   public async close(): Promise<void> {


### PR DESCRIPTION
Fix: https://github.com/casbin/node-casbin/issues/418

See my question int he issues section of the `node-casbin` repo: https://github.com/casbin/node-casbin/issues/418. If there is already a way to do this, or a better pattern, I'm all for it. But I really think this is needed for many enterprise implementations. 