### PR TITLE
feat: create new CasbinRule instance every time sequelize Adapter opens connection

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -15,7 +15,7 @@
 import { Adapter, Helper, Model } from 'casbin';
 import { Op } from 'sequelize';
 import { Sequelize, SequelizeOptions } from 'sequelize-typescript';
-import { createCasbinRule, CasbinRule} from './casbinRule';
+import { createCasbinRule, CasbinRule } from './casbinRule';
 
 export interface SequelizeAdapterOptions extends SequelizeOptions {
   tableName?: string;
@@ -61,7 +61,10 @@ export class SequelizeAdapter implements Adapter {
 
   private async open(): Promise<void> {
     this.sequelize = new Sequelize(this.option);
-    this.CasbinRule = createCasbinRule(this.option.tableName, this.option.schema); // Set the property here
+    this.CasbinRule = createCasbinRule(
+      this.option.tableName,
+      this.option.schema
+    ); // Set the property here
     await this.sequelize.authenticate();
     this.sequelize.addModels([this.CasbinRule]);
     if (this.autoCreateTable) {

--- a/src/casbinRule.ts
+++ b/src/casbinRule.ts
@@ -44,12 +44,16 @@ export class CasbinRule extends Model<CasbinRule> {
   public v5: string;
 }
 
-export function updateCasbinRule(
+export function createCasbinRule(
   tableName = 'casbin_rule',
   schema?: string
-): void {
-  const options = getOptions(CasbinRule.prototype);
+): typeof CasbinRule {
+  class CustomCasbinRule extends CasbinRule {}
+
+  const options = getOptions(CustomCasbinRule.prototype);
   options!.tableName = tableName;
   options!.schema = schema;
-  setOptions(CasbinRule.prototype, options!);
+  setOptions(CustomCasbinRule.prototype, options!);
+
+  return CustomCasbinRule;
 }


### PR DESCRIPTION
Fix: https://github.com/node-casbin/sequelize-adapter/issues/78

**Why?**
Previously, the system utilized multiple adapters to establish connections with different databases based on their respective schemas. However, there was an unintended behavior where the last adapter defined in the configuration would override the previous ones, resulting in only a single database connection being used, regardless of the schema.it supposed that was solved with this [PR](https://github.com/node-casbin/sequelize-adapter/pull/76) but the issue still persists.
**What was changed?**
In the updated code, a new CasbinRule model is dynamically created for each Sequelize adapter instance with the createCasbinRule function. This function generates a custom CasbinRule model class with its own tableName and schema options. This ensures that different Sequelize adapters have isolated configurations, avoiding potential clashes when multiple adapters are opened with different table names or schemas.